### PR TITLE
BUGFIX: Add missing configuration for aop globalObject

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -33,8 +33,16 @@ jobs:
             php-${{ matrix.php-versions }}-flow-${{ matrix.flow-versions }}-composer-
             php-${{ matrix.php-versions }}-flow-
 
+      - name: Create composer.json
+        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress --no-install "^${{ matrix.flow-versions }}"
+
+      - name: Change version of neos/behat to @dev
+        run: composer require "neos/behat:@dev" --dev --no-update
+        working-directory: ${{ env.FLOW_DIST_FOLDER }}
+
       - name: Install composer dependencies
-        run: composer create-project neos/flow-base-distribution ${{ env.FLOW_DIST_FOLDER }} --prefer-dist --no-progress "^${{ matrix.flow-versions }}"
+        run: composer install
+        working-directory: ${{ env.FLOW_DIST_FOLDER }}
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/Configuration/Settings.Aop.yaml
+++ b/Configuration/Settings.Aop.yaml
@@ -1,0 +1,5 @@
+Neos:
+  Flow:
+    aop:
+      globalObjects:
+        addAccountIdentifierToGlobalCacheIdentifier: Netlogix\WebApi\Domain\Service\AddAccountIdentifierToGlobalCacheIdentifierService


### PR DESCRIPTION
AddAccountIdentifierToGlobalCacheIdentifierService needs to
be added to globalObjects in order for the security context to
add the accountIdentifier to the contextHash.