### PR TITLE
BUGFIX: Return command result in createAction

### DIFF
--- a/Classes/Controller/GenericModelController.php
+++ b/Classes/Controller/GenericModelController.php
@@ -54,7 +54,7 @@ class GenericModelController extends BaseGenericModelController
         if ($result instanceof Error) {
             return $this->respondWithError($result);
         }
-        $topLevel = $this->relationshipIterator->createTopLevel($resource);
+        $topLevel = $this->relationshipIterator->createTopLevel($result);
         $this->view->assign('value', $topLevel);
     }
 


### PR DESCRIPTION
To stay jsonapi.org compatible, the WriteModelInterface must implement the Result interface and must be returned by the command handler