### PR TITLE
Add raw errors array to Errors object

### DIFF
--- a/Classes/Domain/Command/Errors.php
+++ b/Classes/Domain/Command/Errors.php
@@ -41,6 +41,20 @@ final class Errors implements \JsonSerializable
         return $this;
     }
 
+    public function addRawErrorArray(array ...$errors): self
+    {
+        foreach ($errors as $error) {
+            $this->issues[] = array_filter([
+                'code' => $error['code'] ?? null,
+                'detail' => $error['detail'] ?? null,
+                'source' => $error['source'] ?? null,
+                'meta' => $error['meta'] ?? null,
+            ]);
+        }
+
+        return $this;
+    }
+
     public function jsonSerialize()
     {
         return $this->issues;


### PR DESCRIPTION
Sometimes commands orchestrate other commands so that single API for the browser result in multiple API callse the first endpoint performs.

In this case there's a chance the nested API call already responds with an error result that can go pretty much unchanged to the browser.

This errors array can now go into an actual Errors object.