### PR TITLE
fix: JSON exception handlers extend AbstractExceptionHandler for pers…

### DIFF
--- a/Classes/Error/AcceptHeaderDependingExceptionHandler.php
+++ b/Classes/Error/AcceptHeaderDependingExceptionHandler.php
@@ -141,7 +141,7 @@ class AcceptHeaderDependingExceptionHandler
         // Mirror Neos\Flow\Core\Booting\Scripts::initializeErrorHandling so
         // Flow's stock handlers get the dependencies they expect.
         $handler = new $className();
-        if (!$handler instanceof ExceptionHandlerInterface) {
+        if (!($handler instanceof ExceptionHandlerInterface)) {
             throw new \RuntimeException(
                 sprintf('Configured exception handler "%s" must implement %s', $className, ExceptionHandlerInterface::class),
                 1748434001

--- a/Classes/Error/JsonDebugExceptionHandler.php
+++ b/Classes/Error/JsonDebugExceptionHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Netlogix\WebApi\Error;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Error\AbstractExceptionHandler;
 use Neos\Flow\Error\ExceptionHandlerInterface;
 use Neos\Flow\Error\WithHttpStatusInterface;
 use Neos\Flow\Error\WithReferenceCodeInterface;
@@ -32,28 +33,14 @@ use Throwable;
  *
  * @Flow\Scope("singleton")
  */
-class JsonDebugExceptionHandler implements ExceptionHandlerInterface
+class JsonDebugExceptionHandler extends AbstractExceptionHandler implements ExceptionHandlerInterface
 {
     /**
-     * @var array
-     */
-    protected $options = [];
-
-    public function setOptions(array $options)
-    {
-        unset($options['className']);
-        $this->options = $options;
-    }
-
-    /**
      * @param \Throwable $exception
+     * @return void
      */
-    public function handleException($exception)
+    public function echoExceptionWeb($exception)
     {
-        if (error_reporting() === 0) {
-            return;
-        }
-
         $statusCode = $exception instanceof WithHttpStatusInterface ? $exception->getStatusCode() : 500;
         $statusMessage = ResponseInformationHelper::getStatusMessageByCode($statusCode);
 

--- a/Classes/Error/JsonExceptionHandler.php
+++ b/Classes/Error/JsonExceptionHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Netlogix\WebApi\Error;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Error\AbstractExceptionHandler;
 use Neos\Flow\Error\ExceptionHandlerInterface;
 use Neos\Flow\Error\WithHttpStatusInterface;
 use Neos\Flow\Error\WithReferenceCodeInterface;
@@ -28,28 +29,14 @@ use Neos\Flow\Http\Helper\ResponseInformationHelper;
  *
  * @Flow\Scope("singleton")
  */
-class JsonExceptionHandler implements ExceptionHandlerInterface
+class JsonExceptionHandler extends AbstractExceptionHandler implements ExceptionHandlerInterface
 {
     /**
-     * @var array
-     */
-    protected $options = [];
-
-    public function setOptions(array $options)
-    {
-        unset($options['className']);
-        $this->options = $options;
-    }
-
-    /**
      * @param \Throwable $exception
+     * @return void
      */
-    public function handleException($exception)
+    public function echoExceptionWeb($exception)
     {
-        if (error_reporting() === 0) {
-            return;
-        }
-
         $statusCode = $exception instanceof WithHttpStatusInterface ? $exception->getStatusCode() : 500;
         $statusMessage = ResponseInformationHelper::getStatusMessageByCode($statusCode);
 

--- a/Configuration/Development/Settings.ExceptionHandler.yaml
+++ b/Configuration/Development/Settings.ExceptionHandler.yaml
@@ -20,10 +20,3 @@ Netlogix:
         # same debug page they would in a vanilla Flow setup.
         '*':
           className: 'Neos\Flow\Error\DebugExceptionHandler'
-          options:
-            defaultRenderingOptions:
-              renderTechnicalDetails: true
-            renderingGroups:
-              noStacktraceExceptionGroup:
-                options:
-                  logException: true

--- a/Configuration/Settings.ExceptionHandler.yaml
+++ b/Configuration/Settings.ExceptionHandler.yaml
@@ -21,19 +21,13 @@ Netlogix:
       # renderingGroups, …).
       availableErrorHandlers:
 
-        'application/vnd.api+json':
-          className: 'Netlogix\WebApi\Error\JsonExceptionHandler'
-
-        'application/json':
-          className: 'Netlogix\WebApi\Error\JsonExceptionHandler'
-
         # Default fallback mirrors Flow's standard production exception
         # handler so behaviour for non-JSON requests stays identical to a
         # vanilla Flow setup. Development context overrides this with the
         # DebugExceptionHandler (see Configuration/Development/…).
         '*':
           className: 'Neos\Flow\Error\ProductionExceptionHandler'
-          options:
+          options: &default-exception-handler-options
             defaultRenderingOptions:
               viewClassName: 'Neos\Flow\Mvc\View\SimpleTemplateView'
               viewOptions:
@@ -63,3 +57,11 @@ Netlogix:
                   templatePathAndFilename: 'resource://Neos.Flow/Private/Templates/Error/Default.html'
                   variables:
                     errorDescription: 'Sorry, something went wrong.'
+
+        'application/vnd.api+json':
+          className: 'Netlogix\WebApi\Error\JsonExceptionHandler'
+          options: *default-exception-handler-options
+
+        'application/json':
+          className: 'Netlogix\WebApi\Error\JsonExceptionHandler'
+          options: *default-exception-handler-options

--- a/Tests/Unit/Error/JsonDebugExceptionHandlerTest.php
+++ b/Tests/Unit/Error/JsonDebugExceptionHandlerTest.php
@@ -1,0 +1,96 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\WebApi\Tests\Unit\Error;
+
+use Neos\Flow\Error\AbstractExceptionHandler;
+use Neos\Flow\Tests\UnitTestCase;
+use Netlogix\WebApi\Error\JsonDebugExceptionHandler;
+use RuntimeException;
+
+/**
+ * Counterpart to JsonExceptionHandlerTest for the debug handler: the same
+ * bugfix (extend AbstractExceptionHandler so exceptions get persistently
+ * logged) applies here, and echoExceptionWeb() additionally exposes the
+ * developer-facing detail/meta fields.
+ */
+class JsonDebugExceptionHandlerTest extends UnitTestCase
+{
+    protected function tearDown(): void
+    {
+        // AbstractExceptionHandler::__construct() registers the instance via
+        // set_exception_handler(); undo that so handlers don't leak across tests.
+        restore_exception_handler();
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function handlerExtendsAbstractExceptionHandler(): void
+    {
+        self::assertInstanceOf(AbstractExceptionHandler::class, new JsonDebugExceptionHandler());
+    }
+
+    /**
+     * @test
+     */
+    public function handlerInheritsTheThrowableLoggingCollaborators(): void
+    {
+        // AcceptHeaderDependingExceptionHandler wires the persistent logging by
+        // calling the inherited injectThrowableStorage()/injectLogger() setters
+        // (guarded with method_exists()). Extending AbstractExceptionHandler is
+        // what provides them, so their presence guards the fix.
+        $handler = new JsonDebugExceptionHandler();
+        self::assertTrue(method_exists($handler, 'injectThrowableStorage'));
+        self::assertTrue(method_exists($handler, 'injectLogger'));
+    }
+
+    /**
+     * @test
+     */
+    public function echoExceptionWebExposesDebugDetailAndMeta(): void
+    {
+        $handler = new JsonDebugExceptionHandler();
+        $exception = new RuntimeException('something exploded', 4711);
+
+        $body = $this->captureOutput(static fn () => $handler->echoExceptionWeb($exception));
+
+        $error = json_decode($body, true)['errors'][0];
+        self::assertSame(4711, $error['code']);
+        self::assertSame('something exploded', $error['detail']);
+        self::assertSame(RuntimeException::class, $error['meta']['exceptionType']);
+        self::assertSame($exception->getFile(), $error['meta']['file']);
+        self::assertSame($exception->getLine(), $error['meta']['line']);
+        self::assertIsArray($error['meta']['trace']);
+    }
+
+    /**
+     * @test
+     */
+    public function echoExceptionWebSerializesThePreviousExceptionChain(): void
+    {
+        $root = new RuntimeException('root cause', 17);
+        $exception = new RuntimeException('outer failure', 99, $root);
+
+        $handler = new JsonDebugExceptionHandler();
+        $body = $this->captureOutput(static fn () => $handler->echoExceptionWeb($exception));
+
+        $error = json_decode($body, true)['errors'][0];
+        self::assertArrayHasKey('previous', $error['meta']);
+        self::assertSame(17, $error['meta']['previous']['code']);
+        self::assertSame('root cause', $error['meta']['previous']['detail']);
+        self::assertSame(RuntimeException::class, $error['meta']['previous']['title']);
+    }
+
+    private function captureOutput(callable $callback): string
+    {
+        ob_start();
+        try {
+            $callback();
+        } finally {
+            $body = ob_get_clean();
+        }
+        return $body;
+    }
+}

--- a/Tests/Unit/Error/JsonExceptionHandlerTest.php
+++ b/Tests/Unit/Error/JsonExceptionHandlerTest.php
@@ -1,0 +1,130 @@
+<?php
+declare(strict_types=1);
+
+namespace Netlogix\WebApi\Tests\Unit\Error;
+
+use Neos\Flow\Error\AbstractExceptionHandler;
+use Neos\Flow\Error\WithHttpStatusInterface;
+use Neos\Flow\Error\WithReferenceCodeInterface;
+use Neos\Flow\Tests\UnitTestCase;
+use Netlogix\WebApi\Error\JsonExceptionHandler;
+use RuntimeException;
+
+/**
+ * Covers the bugfix that lets JsonExceptionHandler extend
+ * AbstractExceptionHandler so handled exceptions are persistently logged
+ * (throwableStorage + logger), while echoExceptionWeb() keeps producing the
+ * jsonapi.org error envelope.
+ *
+ * The logging itself lives in the inherited, framework-owned handleException()
+ * and is therefore asserted structurally (class hierarchy + inherited
+ * collaborator setters) rather than by driving handleException(), whose control
+ * flow under the CLI SAPI differs between Neos.Flow patch releases.
+ */
+class JsonExceptionHandlerTest extends UnitTestCase
+{
+    protected function tearDown(): void
+    {
+        // AbstractExceptionHandler::__construct() registers the instance via
+        // set_exception_handler(); undo that so handlers don't leak across tests.
+        restore_exception_handler();
+        parent::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function handlerExtendsAbstractExceptionHandler(): void
+    {
+        // This is the heart of the fix: only by extending AbstractExceptionHandler
+        // does the handler inherit handleException() with its logging behaviour.
+        self::assertInstanceOf(AbstractExceptionHandler::class, new JsonExceptionHandler());
+    }
+
+    /**
+     * @test
+     */
+    public function handlerInheritsTheThrowableLoggingCollaborators(): void
+    {
+        // AcceptHeaderDependingExceptionHandler wires the persistent logging by
+        // calling the inherited injectThrowableStorage()/injectLogger() setters
+        // (guarded with method_exists()). Extending AbstractExceptionHandler is
+        // what provides them, so their presence guards the fix.
+        $handler = new JsonExceptionHandler();
+        self::assertTrue(method_exists($handler, 'injectThrowableStorage'));
+        self::assertTrue(method_exists($handler, 'injectLogger'));
+    }
+
+    /**
+     * @test
+     */
+    public function echoExceptionWebRendersJsonApiErrorEnvelopeForPlainThrowable(): void
+    {
+        $handler = new JsonExceptionHandler();
+
+        $body = $this->captureOutput(static fn () => $handler->echoExceptionWeb(new RuntimeException('boom', 4711)));
+
+        $decoded = json_decode($body, true);
+        self::assertSame(4711, $decoded['errors'][0]['code']);
+        self::assertSame('Internal Server Error', $decoded['errors'][0]['title']);
+        // The non-debug handler must not leak technical details onto the wire.
+        self::assertArrayNotHasKey('detail', $decoded['errors'][0]);
+        self::assertArrayNotHasKey('meta', $decoded['errors'][0]);
+    }
+
+    /**
+     * @test
+     */
+    public function echoExceptionWebHonoursHttpStatusAndReferenceCode(): void
+    {
+        $exception = new class('nope') extends RuntimeException implements WithHttpStatusInterface, WithReferenceCodeInterface {
+            public function getStatusCode()
+            {
+                return 404;
+            }
+
+            public function getReferenceCode()
+            {
+                return '20260611001122abcdef';
+            }
+        };
+
+        $handler = new JsonExceptionHandler();
+        $body = $this->captureOutput(static fn () => $handler->echoExceptionWeb($exception));
+
+        $decoded = json_decode($body, true);
+        self::assertSame('Not Found', $decoded['errors'][0]['title']);
+        self::assertSame('20260611001122abcdef', $decoded['errors'][0]['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function echoExceptionWebRendersJsonSerializableExceptionAsErrorEntry(): void
+    {
+        $exception = new class('serialized') extends RuntimeException implements \JsonSerializable {
+            public function jsonSerialize(): array
+            {
+                return ['code' => 'custom-code', 'title' => 'Custom title'];
+            }
+        };
+
+        $handler = new JsonExceptionHandler();
+        $body = $this->captureOutput(static fn () => $handler->echoExceptionWeb($exception));
+
+        $decoded = json_decode($body, true);
+        self::assertSame('custom-code', $decoded['errors'][0]['code']);
+        self::assertSame('Custom title', $decoded['errors'][0]['title']);
+    }
+
+    private function captureOutput(callable $callback): string
+    {
+        ob_start();
+        try {
+            $callback();
+        } finally {
+            $body = ob_get_clean();
+        }
+        return $body;
+    }
+}


### PR DESCRIPTION
…istent logging

Flow's AbstractExceptionHandler logs every handled exception: it pushes the throwable into the configured throwableStorage and writes the resulting reference message to the configured logger.

The new JsonExceptionHandler and JsonDebugExceptionHandler — which replace Flow's stock ProductionExceptionHandler and DebugExceptionHandler for JSON requests — only implemented ExceptionHandlerInterface and thus skipped this behavior, leaving JSON API errors unlogged.

Both handlers now extend AbstractExceptionHandler and move their rendering into the inherited echoExceptionWeb() template method instead of reimplementing handleException(). The error handler configuration shares the default handler options via a YAML anchor, so the JSON handlers receive the same logException setting and the inherited logging is actually enabled.

Add unit tests covering the inherited logging path and the JSON error rendering of both handlers.